### PR TITLE
support serde + smaller size for enum usage

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "url2"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["neonphog <neonphog@gmail.com>"]
 edition = "2018"
 description = "ergonomic wrapper around the popular url crate"
@@ -12,4 +12,8 @@ documentation = "https://docs.rs/url2"
 repository = "https://github.com/neonphog/url2"
 
 [dependencies]
-url = "2.1"
+url = { version = "2.1", features = ["serde"] }
+serde = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,24 @@
-# Run tests using local system tools, rather than nix-shell versions
-# Attempts to first ensure the tool versions are compatible
-# Note: You probably want to run the nix-shell version before pushing code
+# Url2 Makefile
 
 .PHONY: all publish test fmt clean tools tool_rust tool_fmt tool_readme
 
-RUSTFLAGS += -D warnings
+#RUSTFLAGS += ...
 
 SHELL = /usr/bin/env sh
 
-ENV = RUSTFLAGS='$(RUSTFLAGS)' CARGO_BUILD_JOBS='$(shell nproc || sysctl -n hw.physicalcpu)' NUM_JOBS='$(shell nproc || sysctl -n hw.physicalcpu)' CARGO_INCREMENTAL='1'
+ENV = RUSTFLAGS='$(RUSTFLAGS)' CARGO_BUILD_JOBS='$(shell nproc || sysctl -n hw.physicalcpu)' NUM_JOBS='$(shell nproc || sysctl -n hw.physicalcpu)'
 
 all: test
 
 publish: tools
 	git diff --exit-code
 	cargo publish
-	VER="v$$(grep version Cargo.toml | cut -d ' ' -f 3 | cut -d \" -f 2)"; git tag -a $$VER -m $$VER
+	VER="v$$(grep version Cargo.toml | head -1 | cut -d ' ' -f 3 | cut -d \" -f 2)"; git tag -a $$VER -m $$VER
 	git push --tags
 
 test: tools
 	$(ENV) cargo fmt -- --check
-	$(ENV) cargo clippy -- \
-		-A clippy::nursery -A clippy::style -A clippy::cargo \
-		-A clippy::pedantic -A clippy::restriction \
-		-D clippy::complexity -D clippy::perf -D clippy::correctness
+	$(ENV) cargo clippy
 	$(ENV) RUST_BACKTRACE=1 cargo test
 	$(ENV) cargo readme -o README.md
 	@if [ "${CI}x" != "x" ]; then git diff --exit-code; fi

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,6 @@ impl std::error::Error for Url2Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self.0 {
             Url2ErrorKind::UrlParseError(ref err) => Some(err),
-            _ => None,
         }
     }
 }
@@ -30,7 +29,6 @@ impl std::fmt::Display for Url2Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self.0 {
             Url2ErrorKind::UrlParseError(ref err) => err.fmt(f),
-            _ => write!(f, "Url2Error::Unknown"),
         }
     }
 }
@@ -48,12 +46,9 @@ impl std::convert::From<url::ParseError> for Url2Error {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 /// enum representing the type of Url2Error
 pub enum Url2ErrorKind {
     /// Url Parsing Error
     UrlParseError(url::ParseError),
-
-    // allow expansion
-    #[doc(hidden)]
-    __Nonexhaustive,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![forbid(missing_docs)]
+#![forbid(warnings)]
+#![forbid(unsafe_code)]
 //! Url2: Ergonomic wrapper around the popular url crate
 //!
 //! # Example
@@ -57,6 +60,7 @@ macro_rules! url2 {
     };
 }
 
+/// Everything you need to work with the Url2 library.
 pub mod prelude {
     // currently, just export everything
     // at some point, we may be more selective

--- a/src/query_unique.rs
+++ b/src/query_unique.rs
@@ -40,8 +40,8 @@ impl<'lt> Url2QueryUnique<'lt> {
     /// );
     /// ```
     pub fn set_pair(self, name: &str, value: &str) -> Self {
-        self.url_ref
-            .unique_cache
+        (self.url_ref.0)
+            .1
             .as_mut()
             .unwrap()
             .insert(name.to_string(), value.to_string());
@@ -59,12 +59,12 @@ impl<'lt> std::ops::Deref for Url2QueryUnique<'lt> {
     type Target = HashMap<String, String>;
 
     fn deref(&self) -> &Self::Target {
-        self.url_ref.unique_cache.as_ref().unwrap()
+        (self.url_ref.0).1.as_ref().unwrap()
     }
 }
 
 impl<'lt> std::ops::DerefMut for Url2QueryUnique<'lt> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.url_ref.unique_cache.as_mut().unwrap()
+        (self.url_ref.0).1.as_mut().unwrap()
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,13 +5,14 @@ extern crate url2;
 fn it_can_try_parse_macro() {
     assert_eq!(
         "test://bob/?a=42",
-        &try_url2!("{}://{}?a={}", "test", "bob", 42)
+        &try_url2!("{}://{}/?a={}", "test", "bob", 42)
             .unwrap()
             .to_string(),
     );
+    // with trailing comma
     assert_eq!(
         "test://bob/?a=42",
-        &try_url2!("{}://{}?a={}", "test", "bob", 42,)
+        &try_url2!("{}://{}/?a={}", "test", "bob", 42,)
             .unwrap()
             .to_string(),
     );
@@ -21,10 +22,11 @@ fn it_can_try_parse_macro() {
 fn it_can_parse_macro() {
     assert_eq!(
         "test://bob/?a=42",
-        &url2!("{}://{}?a={}", "test", "bob", 42).to_string(),
+        &url2!("{}://{}/?a={}", "test", "bob", 42).to_string(),
     );
+    // with trailing comma
     assert_eq!(
         "test://bob/?a=42",
-        &url2!("{}://{}?a={}", "test", "bob", 42,).to_string(),
+        &url2!("{}://{}/?a={}", "test", "bob", 42,).to_string(),
     );
 }


### PR DESCRIPTION
- Allows serde serialize / deserialize for Url2 instances.
- Boxes the inner struct contents to alleviate different sized clips when used in enum variants.